### PR TITLE
SLO 54: Provide non-Gutenberg compat

### DIFF
--- a/admin/class-archive.php
+++ b/admin/class-archive.php
@@ -38,16 +38,22 @@ class Archive {
    * @since 0.0.1
    */
   public function enqueue_slo_missions_plugin() {
-    wp_enqueue_script( 'gpalab-slo-mission-plugin' );
+    $is_gutenberg = get_current_screen()->is_block_editor();
 
-    $missions = get_option( 'gpalab-slo-settings', array() );
+    if ( $is_gutenberg ) {
+      wp_enqueue_script( 'gpalab-slo-mission-plugin' );
 
-    wp_localize_script(
-      'gpalab-slo-mission-plugin',
-      'gpalabSloPlugin',
-      array(
-        'missions' => $missions,
-      )
-    );
+      $missions = get_option( 'gpalab-slo-settings', array() );
+
+      wp_localize_script(
+        'gpalab-slo-mission-plugin',
+        'gpalabSloPlugin',
+        array(
+          'missions' => $missions,
+        )
+      );
+    }
+  }
+
   }
 }

--- a/admin/class-archive.php
+++ b/admin/class-archive.php
@@ -55,5 +55,79 @@ class Archive {
     }
   }
 
+  /**
+   * Adds a legacy metabox to provide compatibility on sites not using the Gutenberg editor.
+   *
+   * @since 0.0.1
+   */
+  public function legacy_compat_metabox() {
+    global $post;
+
+    $is_slo_archive = 'archive-gpalab-social-link.php' === get_post_meta( $post->ID, '_wp_page_template', true );
+
+    // Only show meta box on SLO page template && if Gutenberg is disabled.
+    if ( $is_slo_archive ) {
+      add_meta_box(
+        'gpalab_slo_mission_select',
+        __( 'Connect a Mission', 'gpalab-slo' ),
+        array( $this, 'add_mission_select' ),
+        'page',
+        'side',
+        'high',
+        array(
+          '__back_compat_meta_box' => true,
+        )
+      );
+    }
+  }
+
+  /**
+   * Renders the contents of the legacy metabox.
+   *
+   * @param object $post  WordPress post Object.
+   *
+   * @since 0.0.1
+   */
+  public function add_mission_select( $post ) {
+    // Load in possible HTTP responses.
+    include_once GPALAB_SLO_DIR . 'admin/class-cpt.php';
+    $cpt = new CPT();
+
+    wp_nonce_field( basename( __FILE__ ), 'gpalab_slo_legacy_nonce' );
+
+    $selected = get_post_meta( $post->ID, '_gpalab_slo_mission_select', true );
+    $missions = get_option( 'gpalab-slo-settings' );
+
+    $cpt->populate_mission_select( $selected, $missions, '_gpalab_slo_mission_select' );
+  }
+
+  /**
+   * Save mission value for legacy custom metabox.
+   *
+   * @param int $post_id   WordPress post id.
+   *
+   * @since 0.0.1
+   */
+  public function legacy_mission_meta_save( $post_id ) {
+    // Check save status and validate nonce.
+    $is_autosave    = wp_is_post_autosave( $post_id );
+    $is_revision    = wp_is_post_revision( $post_id );
+    $is_valid_nonce =
+      isset( $_POST['gpalab_slo_legacy_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['gpalab_slo_legacy_nonce'] ) ), basename( __FILE__ ) )
+      ? 'true'
+      : 'false';
+
+    if ( $is_autosave || $is_revision || ! $is_valid_nonce ) {
+      return;
+    }
+
+    // Sanitize/save the post meta.
+    if ( isset( $_POST['_gpalab_slo_mission_select'] ) ) {
+      update_post_meta(
+        $post_id,
+        '_gpalab_slo_mission_select',
+        sanitize_text_field( wp_unslash( $_POST['_gpalab_slo_mission_select'] ) )
+      );
+    }
   }
 }

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -167,18 +167,36 @@ class CPT {
     $selected = get_post_meta( $post->ID, 'gpalab_slo_mission', true );
     $missions = get_option( 'gpalab-slo-settings' );
 
+    $this->populate_mission_select( $selected, $missions, 'gpalab_slo_mission' );
+  }
+
+  /**
+   * Populates the add mission select with a list of mission options.
+   *
+   * @param string $selected   The mission id of the selected mission.
+   * @param array  $missions   A list of available missions.
+   * @param string $meta       The key of the post meta to be saved.
+   *
+   * @since 0.0.1
+   */
+  public function populate_mission_select( $selected, $missions, $meta ) {
+    // Show 'All Posts' as the default option for the SLO page template dropdown.
+    $empty_label = '_gpalab_slo_mission_select' === $meta ? __( 'All Posts', 'gpalab-slo' ) : '';
+
     ?>
 
     <label
-      for="gpalab_slo_mission"
+      for="<?php echo esc_attr( $meta ); ?>"
       style="margin-right: 0.5rem;"
     >
       <?php esc_html_e( 'Select a mission:', 'gpalab-slo' ); ?>
       <select
-        id="gpalab_slo_mission"
-        name="gpalab_slo_mission"
+        id="<?php echo esc_attr( $meta ); ?>"
+        name="<?php echo esc_attr( $meta ); ?>"
       >
-        <option value="" <?php selected( $selected, $mission['id'] ); ?>></option>
+        <option value="" <?php selected( $selected, $mission['id'] ); ?>>
+          <?php echo esc_html( $empty_label ); ?>
+        </option>
         <?php
         foreach ( $missions as $mission ) {
 
@@ -260,7 +278,7 @@ class CPT {
       return;
     }
 
-    // Save status.
+    // Check save status and validate nonce.
     $is_autosave    = wp_is_post_autosave( $post_id );
     $is_revision    = wp_is_post_revision( $post_id );
     $is_valid_nonce =
@@ -272,7 +290,7 @@ class CPT {
       return;
     }
 
-    // Sanitize/save.
+    // Sanitize/save the post meta.
     if ( isset( $_POST['gpalab_slo_link'] ) ) {
       update_post_meta(
         $post_id,

--- a/includes/class-slo.php
+++ b/includes/class-slo.php
@@ -117,6 +117,8 @@ class SLO {
     // Custom post type archive page hooks.
     $this->loader->add_action( 'init', $plugin_archive, 'register_slo_gutenberg_plugins' );
     $this->loader->add_action( 'admin_enqueue_scripts', $plugin_archive, 'enqueue_slo_missions_plugin' );
+    $this->loader->add_action( 'add_meta_boxes', $plugin_archive, 'legacy_compat_metabox' );
+    $this->loader->add_action( 'save_post', $plugin_archive, 'legacy_mission_meta_save' );
 
     // Custom post type hooks.
     $this->loader->add_action( 'init', $plugin_cpt, 'gpalab_slo_cpt', 0 );


### PR DESCRIPTION
The SLO page template has a dropdown to associate the page with a given mission. This dropdown is rendered onto the admin page as a block editor document panel plugin. This implementation depends on the Gutenberg editor being enabled, which cannot be taken for granted. Therefore, this PR adds a legacy custom metabox to provide backwards compatibility for WP installs without Gutenberg. Specifically, it:

1. Only enqueues the document panel plugin JS if Gutenberg is enabled,
1. If Gutenberg is disabled, adds a traditional custom metabox to replicate the functionality of the document panel plugin,
1. The legacy mission dropdown metabox uses the same markup as the mission dropdown in the social links custom post type. As such, I broke out the rendering of that markup as it's own function so that it can be used in multiple places.

Tested by installing and activating the [Classic Editor plugin](https://github.com/WordPress/classic-editor).