### PR TITLE
SLO-60: Create custom capablities

### DIFF
--- a/admin/class-archive.php
+++ b/admin/class-archive.php
@@ -40,7 +40,7 @@ class Archive {
   public function enqueue_slo_missions_plugin() {
     $is_gutenberg = get_current_screen()->is_block_editor();
 
-    if ( $is_gutenberg ) {
+    if ( $is_gutenberg && current_user_can( 'gpalab_slo_edit_slo_page' ) ) {
       wp_enqueue_script( 'gpalab-slo-mission-plugin' );
 
       $missions = get_option( 'gpalab-slo-settings', array() );
@@ -66,7 +66,7 @@ class Archive {
     $is_slo_archive = 'archive-gpalab-social-link.php' === get_post_meta( $post->ID, '_wp_page_template', true );
 
     // Only show meta box on SLO page template && if Gutenberg is disabled.
-    if ( $is_slo_archive ) {
+    if ( $is_slo_archive && current_user_can( 'gpalab_slo_edit_slo_page' ) ) {
       add_meta_box(
         'gpalab_slo_mission_select',
         __( 'Connect a Mission', 'gpalab-slo' ),

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -23,6 +23,19 @@ class CPT {
    * @since 0.0.1
    */
   public function gpalab_slo_cpt() {
+    $capabilities = array(
+      'edit_posts'             => 'gpalab_slo_edit_links',
+      'edit_others_posts'      => 'gpalab_slo_edit_others_links',
+      'edit_private_posts'     => 'gpalab_slo_edit_private_links',
+      'edit_published_posts'   => 'gpalab_slo_edit_published_links',
+      'delete_posts'           => 'gpalab_slo_delete_links',
+      'delete_others_posts'    => 'gpalab_slo_delete_others_links',
+      'delete_private_posts'   => 'gpalab_slo_delete_private_links',
+      'delete_published_posts' => 'gpalab_slo_delete_published_links',
+      'read_private_posts'     => 'gpalab_slo_read_private_links',
+      'publish_posts'          => 'gpalab_slo_delete_links',
+    );
+
     $labels = array(
       'name'                  => _x( 'Social Links', 'Post Type General Name', 'gpalab-slo' ),
       'singular_name'         => _x( 'Social Link', 'Post Type Singular Name', 'gpalab-slo' ),
@@ -79,7 +92,9 @@ class CPT {
       'exclude_from_search' => false,
       'publicly_queryable'  => true,
       'rewrite'             => $rewrite,
-      'capability_type'     => 'post',
+      'capability_type'     => 'gpalab_slo_links',
+      'capabilities'        => $capabilities,
+      'map_meta_cap'        => true,
       'show_in_rest'        => true,
     );
 

--- a/admin/class-permissions.php
+++ b/admin/class-permissions.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Registers the Permissions class.
+ *
+ * @package SLO\Permissions
+ * @since 0.0.1
+ */
+
+namespace SLO;
+
+/**
+ * Handles Permissions calls needed to persist data on the server.
+ *
+ * @package SLO\Permissions
+ * @since 0.0.1
+ */
+class Permissions {
+  /**
+   * The capability required to edit SLO archive pages.
+   *
+   * @var string $edit_cap
+   *
+   * @since 0.0.1
+   */
+  protected $edit_cap;
+
+  /**
+   * Initializes the class with the plugin name and version,
+   * as well as the capability required to edit SLO archive pages.
+   *
+   * @param string $plugin     The plugin name.
+   * @param string $version    The plugin version number.
+   *
+   * @since 0.0.1
+   */
+  public function __construct( $plugin, $version ) {
+    $this->plugin    = $plugin;
+    $this->version   = $version;
+    $this->$edit_cap = 'gpalab_slo_edit_slo_page';
+  }
+
+  /**
+   * Remove the Edit link from the admin bar on the SLO archive page frontend
+   * for admin users without the proper permissions.
+   *
+   * @since 0.0.1
+   */
+  public function slo_archive_remove_admin_bar_edit_link() {
+    $is_gpa_slo_archive = is_page_template( 'archive-gpalab-social-link.php' );
+
+    if ( $is_gpa_slo_archive && ! current_user_can( $this->$edit_cap ) ) {
+      global $wp_admin_bar;
+
+      $wp_admin_bar->remove_menu( 'edit' );
+    }
+  }
+
+  /**
+   * Removes the Edit, Quick Edit, and Trash action buttons from SLO archive
+   * pages if the user doesn't have the appropriate permissions.
+   *
+   * @param array  $actions  List of action links.
+   * @param object $post     WordPress post Object.
+   *
+   * @since 0.0.1
+   */
+  public function disable_actions( $actions = array(), $post = null ) {
+
+    // If the current user can edit SLO archive pages, return all actions.
+    if ( current_user_can( $this->$edit_cap ) ) {
+      return $actions;
+    }
+
+    // If the page template is not an SLO archive page, return all actions.
+    if ( 'archive-gpalab-social-link.php' !== get_post_meta( $post->ID, '_wp_page_template', true ) ) {
+      return $actions;
+    }
+
+    // Remove the Edit link.
+    if ( isset( $actions['edit'] ) ) {
+      unset( $actions['edit'] );
+    }
+
+    // Remove the Quick Edit link.
+    if ( isset( $actions['inline hide-if-no-js'] ) ) {
+      unset( $actions['inline hide-if-no-js'] );
+    }
+
+    // Remove the Trash link.
+    if ( isset( $actions['trash'] ) ) {
+      unset( $actions['trash'] );
+    }
+
+    // Return the set of links without the Edit, Quick Edit, or Trash actions.
+    return $actions;
+  }
+
+  /**
+   * Disables the link to the edit page of a given SLO archive page if the user lacks adequate permissions.
+   *
+   * @param string $url       The edit url for a given post.
+   * @param int    $post_id   The post id for a given post.
+   * @param string $context   How to output the '&' character.
+   *
+   * @since 0.0.1
+   */
+  public function remove_row_title_link( $url, $post_id, $context ) {
+    // If not on the page listings page abort.
+    if ( 'edit-page' !== get_current_screen()->id ) {
+      return;
+    }
+
+    $is_slo_archive = 'archive-gpalab-social-link.php' === get_post_meta( $post_id, '_wp_page_template', true );
+    $has_permission = current_user_can( $this->$edit_cap );
+
+    // If a page is using the SLO template and the user is lacking adequate permissions, disable the edit link.
+    if ( $is_slo_archive && ! $has_permission ) {
+      return null;
+    }
+
+    // Else return the edit URL.
+    return $url;
+  }
+}

--- a/admin/class-permissions.php
+++ b/admin/class-permissions.php
@@ -107,7 +107,7 @@ class Permissions {
   public function remove_row_title_link( $url, $post_id, $context ) {
     // If not on the page listings page abort.
     if ( 'edit-page' !== get_current_screen()->id ) {
-      return;
+      return $url;
     }
 
     $is_slo_archive = 'archive-gpalab-social-link.php' === get_post_meta( $post_id, '_wp_page_template', true );

--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -27,7 +27,7 @@ class Settings {
       'edit.php?post_type=gpalab-social-link',
       __( 'Social Links Settings', 'gpalab-slo' ),
       __( 'Settings', 'gpalab-slo' ),
-      'manage_options',
+      'gpalab_slo_manage_settings',
       'gpalab-slo-settings',
       function() {
         return $this->create_admin_page();

--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -29,6 +29,7 @@ class Activator {
     }
 
     self::initialize_options();
+    self::add_capabilities();
   }
 
   /**
@@ -38,5 +39,49 @@ class Activator {
    */
   private static function initialize_options() {
     add_option( 'gpalab-slo-settings', array() );
+  }
+
+  /**
+   * Add a custom capabilities which permits a user to access certain plugin actions.
+   *
+   * @since 0.0.1
+   */
+  private static function add_capabilities() {
+    // Define capabilities.
+    $manage_settings_cap = 'gpalab_slo_manage_settings';
+    $add_page_cap        = 'gpalab_slo_add_slo_page';
+    $edit_page_cap       = 'gpalab_slo_edit_slo_page';
+
+    $default_admin_cap  = 'manage_options';
+    $default_editor_cap = 'edit_pages';
+    $grant              = true;
+
+    $editable = get_editable_roles();
+
+    // Iterate through all roles, and add custom capabilities to each role that has the default minimum capability.
+    foreach ( wp_roles()->role_objects as $key => $role ) {
+      // Grant settings and SLO page permissions to admin users.
+      if ( isset( $editable[ $key ] ) && $role->has_cap( $default_admin_cap ) ) {
+        $role->add_cap( $manage_settings_cap, $grant );
+        $role->add_cap( $add_page_cap, $grant );
+        $role->add_cap( $edit_page_cap, $grant );
+      }
+
+      // Grant social link permissions to editor users.
+      if ( isset( $editable[ $key ] ) && $role->has_cap( $default_editor_cap ) ) {
+        $role->add_cap( 'gpalab_slo_edit_links', $grant );
+        $role->add_cap( 'gpalab_slo_edit_others_links', $grant );
+        $role->add_cap( 'gpalab_slo_edit_private_links', $grant );
+        $role->add_cap( 'gpalab_slo_edit_published_links', $grant );
+        $role->add_cap( 'gpalab_slo_delete_links', $grant );
+        $role->add_cap( 'gpalab_slo_delete_others_links', $grant );
+        $role->add_cap( 'gpalab_slo_delete_private_links', $grant );
+        $role->add_cap( 'gpalab_slo_delete_published_links', $grant );
+        $role->add_cap( 'gpalab_slo_read_private_links', $grant );
+        $role->add_cap( 'gpalab_slo_delete_links', $grant );
+      }
+    }
+
+    unset( $role );
   }
 }

--- a/includes/class-slo.php
+++ b/includes/class-slo.php
@@ -84,6 +84,7 @@ class SLO {
     require_once GPALAB_SLO_DIR . 'admin/class-ajax.php';
     require_once GPALAB_SLO_DIR . 'admin/class-archive.php';
     require_once GPALAB_SLO_DIR . 'admin/class-cpt.php';
+    require_once GPALAB_SLO_DIR . 'admin/class-permissions.php';
     require_once GPALAB_SLO_DIR . 'admin/class-settings.php';
 
     // The class responsible for defining all actions that occur in the public-facing side of the site.
@@ -103,6 +104,7 @@ class SLO {
     $plugin_ajax     = new SLO\Ajax( $this->get_plugin_name(), $this->get_version() );
     $plugin_archive  = new SLO\Archive( $this->get_plugin_name(), $this->get_version() );
     $plugin_cpt      = new SLO\CPT( $this->get_plugin_name(), $this->get_version() );
+    $plugin_roles    = new SLO\Permissions( $this->get_plugin_name(), $this->get_version() );
     $plugin_settings = new SLO\Settings( $this->get_plugin_name(), $this->get_version() );
 
     // Admin hooks.
@@ -137,6 +139,11 @@ class SLO {
     $this->loader->add_action( 'admin_init', $plugin_settings, 'populate_settings_page' );
     $this->loader->add_action( 'admin_enqueue_scripts', $plugin_settings, 'enqueue_slo_admin' );
     $this->loader->add_filter( 'plugin_action_links_social-link-optimizer/social-link-optimizer.php', $plugin_settings, 'add_settings_link' );
+
+    // User roles and permissions hooks.
+    $this->loader->add_action( 'wp_before_admin_bar_render', $plugin_roles, 'slo_archive_remove_admin_bar_edit_link' );
+    $this->loader->add_filter( 'page_row_actions', $plugin_roles, 'disable_actions', 10, 2 );
+    $this->loader->add_filter( 'get_edit_post_link', $plugin_roles, 'remove_row_title_link', 10, 3 );
   }
 
   /**

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -31,6 +31,7 @@ class Uninstall {
     if ( ! is_multisite() ) {
 
       self::remove_options();
+      self::remove_capabilities();
       self::delete_slo_page_meta();
       self::reset_slo_page_templates();
       self::delete_slo_cpts();
@@ -50,6 +51,7 @@ class Uninstall {
         switch_to_blog( $id );
 
         self::remove_options();
+        self::remove_capabilities();
         self::delete_slo_page_meta();
         self::reset_slo_page_templates();
         self::delete_slo_cpts();
@@ -69,6 +71,45 @@ class Uninstall {
    */
   private static function remove_options() {
     delete_option( 'gpalab-slo-settings' );
+  }
+
+  /**
+   * Remove the custom capabilities added by the plugin.
+   *
+   * @since 0.0.1
+   */
+  private static function remove_capabilities() {
+    $custom_caps = array(
+      'gpalab_slo_manage_settings',
+      'gpalab_slo_add_slo_page',
+      'gpalab_slo_edit_slo_page',
+      'gpalab_slo_edit_links',
+      'gpalab_slo_edit_others_links',
+      'gpalab_slo_edit_private_links',
+      'gpalab_slo_edit_published_links',
+      'gpalab_slo_delete_links',
+      'gpalab_slo_delete_others_links',
+      'gpalab_slo_delete_private_links',
+      'gpalab_slo_delete_published_links',
+      'gpalab_slo_read_private_links',
+      'gpalab_slo_delete_links',
+    );
+
+    $editable = get_editable_roles();
+
+    foreach ( $custom_caps as $cap ) {
+
+      foreach ( wp_roles()->role_objects as $key => $role ) {
+
+        if ( isset( $editable[ $key ] ) && $role->has_cap( $cap ) ) {
+          $role->remove_cap( $cap );
+        }
+
+        unset( $role );
+      }
+    }
+
+    unset( $cap );
   }
 
   /**

--- a/public/class-template.php
+++ b/public/class-template.php
@@ -44,16 +44,19 @@ class Template {
     );
   }
 
-  // }
-
   /**
    * Adds our template to the page dropdown for v4.7+
    *
    * @param array $posts_templates   List of available post templates.
-   *
+   * @return array                   Updated list of available page templates
    * @since 0.0.1
    */
   public function add_new_template( $posts_templates ) {
+    // If the user lacks the proper permission return the standard list of templates.
+    if ( ! current_user_can( 'gpalab_slo_add_slo_page' ) ) {
+      return $posts_templates;
+    }
+
     $posts_templates = array_merge( $posts_templates, $this->templates );
 
     return $posts_templates;

--- a/social-link-optimizer.php
+++ b/social-link-optimizer.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Plugin Name:       Social Link Optimizer
- * Plugin URI:        https://github.com/IIP-Design/social-link-optimizer
- * Description:       Adds a Social Link custom post type, custom meta box, and Social Link Optimizer page template
- * Version:           0.0.1
- * Author:            U.S. Department of State, Bureau of Global Public Affairs Digital Lab <gpa-lab@america.gov>
- * Author URI:        https://lab.america.gov
- * License:           GNU General Public License v2.0
- * License URI:       https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
- * Text Domain:       gpalab-slo
+ * Plugin Name: Social Link Optimizer
+ * Plugin URI: https://github.com/IIP-Design/social-link-optimizer
+ * Description: Adds a Social Link custom post type, custom meta box, and Social Link Optimizer page template
+ * Version: v0.0.1
+ * Author: U.S. Department of State, Bureau of Global Public Affairs Digital Lab <gpa-lab@america.gov>
+ * Author URI: https://lab.america.gov
+ * License: GNU General Public License v2.0
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+ * Text Domain: gpalab-slo
  *
  * @package GPALAB_SLO
  */


### PR DESCRIPTION
1. During the custom post type registration, adds a set of custom capabilities pertaining to the editing of Social Link custom post types.
1. On activation, adds a set of custom capabilities to:
    - Manage the plugin settings
    - Add SLO archive pages
    - Edit SLO archive pages.
1. On activation, assigns the Social Links permission set to all users with the Editor and above role.
1. On activation, assigns the settings and SLO archive page permissions to all users with the Administrator role.
1. Restricts access to Social Links and SLO archive pages according to the custom capabilities.
1. On uninstall, removes all custom capabilities.