### PR TITLE
Checks for get_current_screen existence

### DIFF
--- a/admin/class-permissions.php
+++ b/admin/class-permissions.php
@@ -106,7 +106,7 @@ class Permissions {
    */
   public function remove_row_title_link( $url, $post_id, $context ) {
     // If not on the page listings page abort.
-    if ( function_exists( 'get_current_screen' ) && 'edit-page' !== get_current_screen()->id ) {
+    if ( is_admin() && 'edit-page' !== get_current_screen()->id ) {
       return $url;
     }
 

--- a/admin/class-permissions.php
+++ b/admin/class-permissions.php
@@ -106,7 +106,7 @@ class Permissions {
    */
   public function remove_row_title_link( $url, $post_id, $context ) {
     // If not on the page listings page abort.
-    if ( 'edit-page' !== get_current_screen()->id ) {
+    if ( function_exists( 'get_current_screen' ) && 'edit-page' !== get_current_screen()->id ) {
       return $url;
     }
 


### PR DESCRIPTION
I'm getting this error on the mission pages:

```
Fatal error: Uncaught Error: Call to undefined function SLO\get_current_screen() in class-permissions.php on line 110
```
This also explains why the admin bar doesn't currently appear on the mission pages on the staging site.

I'm not entirely sure why `get_current_screen` is `undefined`. Perhaps it's only available from the dashboard and not the front or maybe because it's hooking into `get_edit_post_link`. But adding `function_exists( 'get_current_screen' )` seems to fix it.