### PR TITLE
SLO-71: Remove Custom Fields Metabox

### DIFF
--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -122,7 +122,7 @@ class CPT {
       array( $this, 'add_mission_select' ),
       'gpalab-social-link',
       'side',
-      'low'
+      'high'
     );
 
     add_meta_box(

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -133,6 +133,12 @@ class CPT {
       'side',
       'high'
     );
+
+    remove_meta_box(
+      'postcustom',
+      'gpalab-social-link',
+      'normal'
+    );
   }
 
   /**


### PR DESCRIPTION
In our user test with Mrudula, she was a bit confused by the Custom Fields metabox. It creates a lot of visual clutter and is actually not intended to be interacted with. As such, this PR simply removes that metabox from the social links edit screen (custom post types support for custom fields must be maintained so that we can add custom postmeta data).

Additionally, I bumped the mission select dropdown to the top of the edit page sidebar.