### PR TITLE
Cleanup

### DIFF
--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -465,6 +465,8 @@ class CPT {
    *
    * @param array $msg   List of messages shown to the user on update.
    * @return array       Updated list with custom messages for gpalab-social-links.
+   *
+   * @since 0.0.1
    */
   public function social_link_updated_messages( $msg ) {
 
@@ -499,5 +501,19 @@ class CPT {
     );
 
     return $msg;
+  }
+
+  /**
+   * Remove the View link from the admin bar for social links.
+   *
+   * @param object $wp_admin_bar  List of nodes to appear in the admin bar.
+   *
+   * @since 0.0.1
+   */
+  public function remove_view_from_admin_bar( $wp_admin_bar ) {
+
+    if ( is_admin() && 'gpalab-social-link' === get_current_screen()->post_type ) {
+      $wp_admin_bar->remove_node( 'view' );
+    }
   }
 }

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -67,24 +67,24 @@ class CPT {
       'parent_item_colon'     => __( 'Parent Item:', 'gpalab-slo' ),
       'all_items'             => __( 'All Links', 'gpalab-slo' ),
       'add_new_item'          => __( 'Add New Link', 'gpalab-slo' ),
-      'add_new'               => __( 'Add New', 'gpalab-slo' ),
+      'add_new'               => __( 'Add New Link', 'gpalab-slo' ),
       'new_item'              => __( 'New Item', 'gpalab-slo' ),
-      'edit_item'             => __( 'Edit Item', 'gpalab-slo' ),
+      'edit_item'             => __( 'Edit Social Link', 'gpalab-slo' ),
       'update_item'           => __( 'Update Item', 'gpalab-slo' ),
-      'view_item'             => __( 'View Item', 'gpalab-slo' ),
+      'view_item'             => __( 'View Link', 'gpalab-slo' ),
       'view_items'            => __( 'View Links', 'gpalab-slo' ),
-      'search_items'          => __( 'Search Link', 'gpalab-slo' ),
+      'search_items'          => __( 'Search Links', 'gpalab-slo' ),
       'not_found'             => __( 'Not found', 'gpalab-slo' ),
       'not_found_in_trash'    => __( 'Not found in Trash', 'gpalab-slo' ),
-      'featured_image'        => __( 'Featured Image', 'gpalab-slo' ),
-      'set_featured_image'    => __( 'Set featured image', 'gpalab-slo' ),
-      'remove_featured_image' => __( 'Remove featured image', 'gpalab-slo' ),
-      'use_featured_image'    => __( 'Use as featured image', 'gpalab-slo' ),
+      'featured_image'        => __( 'Linked Image', 'gpalab-slo' ),
+      'set_featured_image'    => __( 'Add an image to the grid', 'gpalab-slo' ),
+      'remove_featured_image' => __( 'Remove image', 'gpalab-slo' ),
+      'use_featured_image'    => __( 'Use as grid image', 'gpalab-slo' ),
       'insert_into_item'      => __( 'Insert into item', 'gpalab-slo' ),
       'uploaded_to_this_item' => __( 'Uploaded to this item', 'gpalab-slo' ),
-      'items_list'            => __( 'Items list', 'gpalab-slo' ),
-      'items_list_navigation' => __( 'Items list navigation', 'gpalab-slo' ),
-      'filter_items_list'     => __( 'Filter items list', 'gpalab-slo' ),
+      'items_list'            => __( 'Link list', 'gpalab-slo' ),
+      'items_list_navigation' => __( 'Link list navigation', 'gpalab-slo' ),
+      'filter_items_list'     => __( 'Filter link list', 'gpalab-slo' ),
     );
 
     $rewrite = array(
@@ -96,7 +96,7 @@ class CPT {
 
     $args = array(
       'label'               => __( 'Social Link', 'gpalab-slo' ),
-      'description'         => __( 'Post Type Description', 'gpalab-slo' ),
+      'description'         => __( 'Links used to populate mission social link pages', 'gpalab-slo' ),
       'labels'              => $labels,
       'supports'            => array( 'title', 'thumbnail', 'custom-fields' ),
       'taxonomies'          => array(),
@@ -130,7 +130,7 @@ class CPT {
   public function gpalab_slo_custom_meta() {
     add_meta_box(
       'gpalab_slo_link',
-      __( 'Link this social post to', 'gpalab-slo' ),
+      __( 'Add a Link to This Social Post', 'gpalab-slo' ),
       array( $this, 'add_link_input' ),
       'gpalab-social-link',
       'normal',
@@ -398,7 +398,7 @@ class CPT {
 
     add_meta_box(
       'postimagediv',
-      __( 'Featured Image' ),
+      __( 'Add a Grid Image', 'gpalab-slo' ),
       'post_thumbnail_meta_box',
       'gpalab-social-link',
       'normal', // move to normal from side.

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -89,9 +89,9 @@ class CPT {
 
     $rewrite = array(
       'slug'       => 'gpalab-social-link',
-      'with_front' => true,
+      'with_front' => false,
       'pages'      => true,
-      'feeds'      => true,
+      'feeds'      => false,
     );
 
     $args = array(
@@ -414,18 +414,17 @@ class CPT {
    *
    * @since 0.0.1
    */
-  public function single_link_template( $single ) {
+  public function preview_link_template( $single ) {
     global $post;
 
     /* Checks for single template by post type */
     if ( 'gpalab-social-link' === $post->post_type ) {
-      if ( file_exists( GPALAB_SLO_DIR . '/templates/single-gpalab-social-link.php' ) ) {
-        return GPALAB_SLO_DIR . '/templates/single-gpalab-social-link.php';
+      if ( file_exists( GPALAB_SLO_DIR . '/templates/preview-gpalab-social-link.php' ) ) {
+        return GPALAB_SLO_DIR . '/templates/preview-gpalab-social-link.php';
       }
     }
 
     return $single;
-
   }
 
   /**

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -36,18 +36,26 @@ class CPT {
    * @since 0.0.1
    */
   public function gpalab_slo_cpt() {
+    /**
+     * Private post capabilities are disabled as we don't anticipate their use.
+     * If eventually enabled, the corresponding change should be made in the
+     * Activator and Uninstall classes found in the includes directory as well
+     * as in the URE class found in this directory.
+     */
+    // phpcs:disable Squiz.PHP.CommentedOutCode.Found
     $capabilities = array(
       'edit_posts'             => 'gpalab_slo_edit_links',
       'edit_others_posts'      => 'gpalab_slo_edit_others_links',
-      'edit_private_posts'     => 'gpalab_slo_edit_private_links',
       'edit_published_posts'   => 'gpalab_slo_edit_published_links',
       'delete_posts'           => 'gpalab_slo_delete_links',
       'delete_others_posts'    => 'gpalab_slo_delete_others_links',
-      'delete_private_posts'   => 'gpalab_slo_delete_private_links',
       'delete_published_posts' => 'gpalab_slo_delete_published_links',
-      'read_private_posts'     => 'gpalab_slo_read_private_links',
-      'publish_posts'          => 'gpalab_slo_delete_links',
+      'publish_posts'          => 'gpalab_slo_publish_links',
+      // 'edit_private_posts'     => 'gpalab_slo_edit_private_links',
+      // 'delete_private_posts'   => 'gpalab_slo_delete_private_links',
+      // 'read_private_posts'     => 'gpalab_slo_read_private_links',
     );
+    // phpcs:enable
 
     $labels = array(
       'name'                  => _x( 'Social Links', 'Post Type General Name', 'gpalab-slo' ),
@@ -439,15 +447,16 @@ class CPT {
   }
 
   /**
-   * Hides the permalink below the post title on the social edit link to avoid confusion.
+   * Hides the permalink below the post title and the post visibility
+   * settings on the social link edit screen to avoid confusion.
    *
    * @since 0.0.1
    */
-  public function hide_permalink() {
+  public function hide_unused_elements() {
     global $post_type;
 
     if ( 'gpalab-social-link' === $post_type ) {
-      echo '<style type="text/css">#edit-slug-box{display: none;}</style>';
+      echo '<style type="text/css">#edit-slug-box, #visibility{display: none;}</style>';
     }
   }
 

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -110,7 +110,7 @@ class CPT {
       'show_in_nav_menus'   => true,
       'can_export'          => true,
       'has_archive'         => false,
-      'exclude_from_search' => false,
+      'exclude_from_search' => true,
       'publicly_queryable'  => true,
       'rewrite'             => $rewrite,
       'capability_type'     => 'gpalab_slo_links',

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -144,7 +144,7 @@ class CPT {
       array( $this, 'add_archive_checkbox' ),
       'gpalab-social-link',
       'side',
-      'high'
+      'low'
     );
 
     /**

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -116,7 +116,7 @@ class CPT {
       'capability_type'     => 'gpalab_slo_links',
       'capabilities'        => $capabilities,
       'map_meta_cap'        => true,
-      'show_in_rest'        => true,
+      'show_in_rest'        => false,
     );
 
     register_post_type( 'gpalab-social-link', $args );

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -238,7 +238,7 @@ class CPT {
         id="<?php echo esc_attr( $meta ); ?>"
         name="<?php echo esc_attr( $meta ); ?>"
       >
-        <option value="" <?php selected( $selected, $mission['id'] ); ?>>
+        <option value="" <?php selected( $selected, '' ); ?>>
           <?php echo esc_html( $empty_label ); ?>
         </option>
         <?php
@@ -459,6 +459,8 @@ class CPT {
    */
   public function social_link_updated_messages( $msg ) {
 
+    global $post;
+
     /* translators: %s: date and time of the revision */
     $revision = __( 'Social link restored to revision from %s.', 'gpalab-slo' );
 
@@ -469,7 +471,9 @@ class CPT {
     // phpcs:enable
 
     /* translators: %s: date and time for which publishing is scheduled */
-    $scheduled = __( 'Social link scheduled for: %s.', 'gpalab-slo' );
+    $scheduled = __( 'Social link publication scheduled for: %s.', 'gpalab-slo' );
+
+    $scheduled_date = date_i18n( __( 'M j, Y @ H:i' ), strtotime( $post->post_date ) );
 
     $msg['gpalab-social-link'] = array(
       0  => '', // Unused. Messages start at index 1.

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -109,7 +109,7 @@ class CPT {
       'show_in_admin_bar'   => true,
       'show_in_nav_menus'   => true,
       'can_export'          => true,
-      'has_archive'         => true,
+      'has_archive'         => false,
       'exclude_from_search' => false,
       'publicly_queryable'  => true,
       'rewrite'             => $rewrite,

--- a/admin/class-ure.php
+++ b/admin/class-ure.php
@@ -59,20 +59,28 @@ class URE {
    * @since 0.0.1
    */
   public function get_plugin_caps( $groups, $cap_id ) {
+    /**
+     * Private post capabilities are disabled as we don't anticipate their use.
+     * To implement them, add the following capabilities to the below array:
+     *   - 'gpalab_slo_read_private_links'
+     *   - 'gpalab_slo_edit_private_links'
+     *   - 'gpalab_slo_delete_private_links'
+     *
+     * If eventually enabled, the corresponding change should be made in the
+     * Activator and Uninstall classes found in the includes directory as well
+     * as in the CPT class found in this directory.
+     */
     $plugin_caps = array(
       'gpalab_slo_manage_settings',
       'gpalab_slo_add_slo_page',
       'gpalab_slo_edit_slo_page',
       'gpalab_slo_edit_links',
       'gpalab_slo_edit_others_links',
-      'gpalab_slo_edit_private_links',
       'gpalab_slo_edit_published_links',
       'gpalab_slo_delete_links',
       'gpalab_slo_delete_others_links',
-      'gpalab_slo_delete_private_links',
       'gpalab_slo_delete_published_links',
-      'gpalab_slo_read_private_links',
-      'gpalab_slo_delete_links',
+      'gpalab_slo_publish_links',
     );
 
     if ( in_array( $cap_id, $plugin_caps, true ) ) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,18 +122,15 @@ The three core capabilities are:
 
 By default, only users assigned the role `Admin` will have these core capabilities.
 
-The plugin also adds a group of capabilities pertaining to the creation/editing of individual social links. These capabilities correspond to the set of capabilities used to manage posts/pages and provide the [equivalent permission](https://developer.wordpress.org/reference/functions/get_post_type_capabilities/). They are:
+The plugin also adds a group of capabilities pertaining to the creation/editing of individual social links. These capabilities correspond to the set of capabilities used to manage posts/pages and provide the [equivalent permission](https://developer.wordpress.org/reference/functions/get_post_type_capabilities/) (excluding those for private posts). They are:
 
 - `gpalab_slo_edit_links`
 - `gpalab_slo_edit_others_links`
-- `gpalab_slo_edit_private_links`
 - `gpalab_slo_edit_published_links`
 - `gpalab_slo_delete_links`
 - `gpalab_slo_delete_others_links`
-- `gpalab_slo_delete_private_links`
 - `gpalab_slo_delete_published_links`
-- `gpalab_slo_read_private_links`
-- `gpalab_slo_delete_links`
+- `gpalab_slo_publish_links`
 
 By default, users with the role `Editor` and higher have access to these capabilities.
 

--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -67,19 +67,28 @@ class Activator {
         $role->add_cap( $edit_page_cap, $grant );
       }
 
-      // Grant social link permissions to editor users.
+      /**
+       * Grant social link permissions to editor users.
+       *
+       * Private post capabilities are disabled as we don't anticipate their use.
+       * If eventually enabled, the corresponding change should be made in the
+       * CPT and URE classes found in the admin directory as well as in the
+       * Uninstall class found in this directory.
+       */
+      // phpcs:disable Squiz.PHP.CommentedOutCode.Found
       if ( isset( $editable[ $key ] ) && $role->has_cap( $default_editor_cap ) ) {
         $role->add_cap( 'gpalab_slo_edit_links', $grant );
         $role->add_cap( 'gpalab_slo_edit_others_links', $grant );
-        $role->add_cap( 'gpalab_slo_edit_private_links', $grant );
         $role->add_cap( 'gpalab_slo_edit_published_links', $grant );
         $role->add_cap( 'gpalab_slo_delete_links', $grant );
         $role->add_cap( 'gpalab_slo_delete_others_links', $grant );
-        $role->add_cap( 'gpalab_slo_delete_private_links', $grant );
         $role->add_cap( 'gpalab_slo_delete_published_links', $grant );
-        $role->add_cap( 'gpalab_slo_read_private_links', $grant );
-        $role->add_cap( 'gpalab_slo_delete_links', $grant );
+        $role->add_cap( 'gpalab_slo_publish_links', $grant );
+        // $role->add_cap( 'gpalab_slo_read_private_links', $grant );
+        // $role->add_cap( 'gpalab_slo_edit_private_links', $grant );
+        // $role->add_cap( 'gpalab_slo_delete_private_links', $grant );
       }
+      // phpcs:enable
     }
 
     unset( $role );

--- a/includes/class-slo.php
+++ b/includes/class-slo.php
@@ -133,7 +133,7 @@ class SLO {
     $this->loader->add_filter( 'post_type_link', $plugin_cpt, 'gpalab_slo_filter_permalink', 10, 2 );
     $this->loader->add_filter( 'single_template', $plugin_cpt, 'single_link_template' );
     $this->loader->add_filter( 'preview_post_link', $plugin_cpt, 'hijack_slo_preview' );
-    $this->loader->add_action( 'admin_head', $plugin_cpt, 'hide_permalink' );
+    $this->loader->add_action( 'admin_head', $plugin_cpt, 'hide_unused_elements' );
     $this->loader->add_filter( 'post_updated_messages', $plugin_cpt, 'social_link_updated_messages', 10, 1 );
 
     // Hooks to manage the All Links page.

--- a/includes/class-slo.php
+++ b/includes/class-slo.php
@@ -131,7 +131,7 @@ class SLO {
     $this->loader->add_action( 'save_post', $plugin_cpt, 'gpalab_slo_meta_save' );
     $this->loader->add_action( 'do_meta_boxes', $plugin_cpt, 'gpalab_slo_image_meta_box' );
     $this->loader->add_filter( 'post_type_link', $plugin_cpt, 'gpalab_slo_filter_permalink', 10, 2 );
-    $this->loader->add_filter( 'single_template', $plugin_cpt, 'single_link_template' );
+    $this->loader->add_filter( 'single_template', $plugin_cpt, 'preview_link_template' );
     $this->loader->add_filter( 'preview_post_link', $plugin_cpt, 'hijack_slo_preview' );
     $this->loader->add_action( 'admin_head', $plugin_cpt, 'hide_unused_elements' );
     $this->loader->add_filter( 'post_updated_messages', $plugin_cpt, 'social_link_updated_messages', 10, 1 );

--- a/includes/class-slo.php
+++ b/includes/class-slo.php
@@ -135,6 +135,7 @@ class SLO {
     $this->loader->add_filter( 'preview_post_link', $plugin_cpt, 'hijack_slo_preview' );
     $this->loader->add_action( 'admin_head', $plugin_cpt, 'hide_unused_elements' );
     $this->loader->add_filter( 'post_updated_messages', $plugin_cpt, 'social_link_updated_messages', 10, 1 );
+    $this->loader->add_action( 'admin_bar_menu', $plugin_cpt, 'remove_view_from_admin_bar', 999 );
 
     // Hooks to manage the All Links page.
     $this->loader->add_action( 'manage_gpalab-social-link_posts_custom_column', $plugin_cpt_list, 'populate_custom_columns', 10, 2 );

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -79,20 +79,28 @@ class Uninstall {
    * @since 0.0.1
    */
   private static function remove_capabilities() {
+    /**
+     * Private post capabilities are disabled as we don't anticipate their use.
+     * To implement them, add the following capabilities to the below array:
+     *   - 'gpalab_slo_read_private_links'
+     *   - 'gpalab_slo_edit_private_links'
+     *   - 'gpalab_slo_delete_private_links'
+     *
+     * If eventually enabled, the corresponding change should be made in the
+     * CPT and URE classes found in the admin directory as well as in the
+     * Activator class found in this directory.
+     */
     $custom_caps = array(
       'gpalab_slo_manage_settings',
       'gpalab_slo_add_slo_page',
       'gpalab_slo_edit_slo_page',
       'gpalab_slo_edit_links',
       'gpalab_slo_edit_others_links',
-      'gpalab_slo_edit_private_links',
       'gpalab_slo_edit_published_links',
       'gpalab_slo_delete_links',
       'gpalab_slo_delete_others_links',
-      'gpalab_slo_delete_private_links',
       'gpalab_slo_delete_published_links',
-      'gpalab_slo_read_private_links',
-      'gpalab_slo_delete_links',
+      'gpalab_slo_publish_links',
     );
 
     $editable = get_editable_roles();

--- a/templates/preview-gpalab-social-link.php
+++ b/templates/preview-gpalab-social-link.php
@@ -12,6 +12,14 @@
   * preview how a social link would look once published.
   */
 
+// If the user is not hitting a preview URL, redirect them to the homepage.
+// phpcs:disable WordPress.Security.NonceVerification.Recommended
+if ( ! isset( $_GET['preview'] ) || 'true' !== sanitize_text_field( wp_unslash( $_GET['preview'] ) ) ) {
+  wp_safe_redirect( home_url() );
+  exit;
+}
+// phpcs:enable
+
 require 'template-parts/header-slo.php';
 
 ?>


### PR DESCRIPTION
Odds and ends to tidy up the Social Link custom post type administrative interface. Specifically:

- De-prioritize the **Archive** metabox so it is less prominent (per user feedback)
- Remove social links from site search and the WP rest API
- Rename the `single-gpalab-social-links` template as `preview-gpalab-social-links` to explicitly identify it as the preview template, and only make it accessible if in fact opened as part of a preview.
- Hide the visibility setting in the publish box since we're not utilizing the private or password protected posts feature for this custom post type. Remove the corresponding custom capabilities to simplify role management somewhat.
- Remove the `View Item` link from the admin bar for the same reason we removed the `View` links elsewhere in SLO-75.
- Reword several labels and titles across the Social Link admin interface.
