### PR TITLE
SLO-77: Add initial documentation for admin users

### DIFF
--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -14,6 +14,9 @@
       <li class="nav-item" role="listitem">
         <a href="#permissions">Permissions</a>
       </li>
+      <li class="nav-item" role="listitem">
+        <a href="{{ site.github.url }}/admin-user-guide">Guide for Web Managers</a>
+      </li>
     </ul>
   </nav>
 </div>

--- a/docs/admin-user-guide.md
+++ b/docs/admin-user-guide.md
@@ -1,0 +1,19 @@
+### Add a New Mission
+
+From the WordPress admin dashboard, navigate to the **Social Links > Settings** sub-menu in the admin sidebar on the left hand side.
+
+Click the **Add Mission** button to add a new mission to the site. This will show a form wherein you can configure the mission. Add a mission name, website URL, choose the display settings (grid of images or list), and provide links to the mission's social media properties. When the form is complete to your satisfaction, click **Save Changes** to save the newly added mission.
+
+### Remove a Mission
+
+Navigate to the plugin settings at **Social Links > Settings**. Click on the tab of the mission that you would like to remove. At the bottom of the mission form, click on **Remove This Mission**.
+
+### Add a Mission Page
+
+From the WordPress admin dashboard, go to the **Pages** section and click on **Add New** to add a new page. Once the editor for the new page is open, find the **Page Attributes** section in the sidebar on the right side of the page editor. (Note that if you do not see a sidebar in the editor view, click the black gear icon on the top right of the page to toggle it on.) Within the **Page Attributes** section, select **Social Link Optimizer** from the list of options under **Template** dropdown.
+
+This should add a new section to the sidebar called **Connect a Mission**. In this section, you can associate the newly created page with any mission added in the social link settings ([see above](#add-a-new-mission)). Within the **Connect a Mission** section, select the mission you would like to link this page to using the **Select from Available Missions** dropdown.
+
+Additionally, you should add a page title (at the top of the page where it says "Add Title") and a featured image to the **Featured Image** section in the editor sidebar. The title will appear as the page heading and the featured image will serve as the avatar image on the top of the page.
+
+When finished editing the page, click on the **Publish** button to save your changes and publish the page. (If you want to save without publishing, click on the **Save draft** to the left of the **Publish** button.)


### PR DESCRIPTION
Add's text explaining how to add a mission and an SLO page. Missing screen captures. Note that all of this is subject to change if we automate the SLO page generation.

Adds a link to this documentation page to the in-repo docs GitHub pages site.