### PR TITLE
SLO-111: Helper text for ideal dimensions for image uploader

### DIFF
--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -347,6 +347,28 @@ class CPT {
   }
 
   /**
+   * Add image dimensions helper text to the image meta box.
+   *
+   * @param string $content Admin post thumbnail HTML markup.
+   * @return string         The metabox content with helper text.
+   *
+   * @since 0.0.1
+   */
+  public function gpalab_slo_image_meta_box_helper_text( $content ) {
+    global $post_type;
+
+    $is_social_link = 'gpalab-social-link' === $post_type;
+
+    if ( ! $is_social_link ) {
+      return $content;
+    }
+
+    $helper_text = '<p>' . esc_html__( 'For optimal resolution: image should be at least 1080 &times; 1080 (width &times; height) with an aspect ratio of 1:1 (square), 1.91:1 (landscape), and 4:5 (portrait).', 'gpalab-slo' ) . '</p>';
+
+    return $helper_text . $content;
+  }
+
+  /**
    * When loading gpalab-social-link posts, load the post template provided by the plugin.
    *
    * @param string $single   The path to the appropriate single template.

--- a/includes/class-slo.php
+++ b/includes/class-slo.php
@@ -144,6 +144,7 @@ class SLO {
     $this->loader->add_action( 'add_meta_boxes', $plugin_cpt, 'gpalab_slo_custom_meta' );
     $this->loader->add_action( 'save_post', $plugin_cpt, 'gpalab_slo_meta_save' );
     $this->loader->add_action( 'do_meta_boxes', $plugin_cpt, 'gpalab_slo_image_meta_box' );
+    $this->loader->add_filter( 'admin_post_thumbnail_html', $plugin_cpt, 'gpalab_slo_image_meta_box_helper_text', 10, 1 );
     $this->loader->add_filter( 'post_type_link', $plugin_cpt, 'gpalab_slo_filter_permalink', 10, 2 );
     $this->loader->add_filter( 'single_template', $plugin_cpt, 'preview_link_template' );
     $this->loader->add_filter( 'preview_post_link', $plugin_cpt, 'hijack_slo_preview' );


### PR DESCRIPTION
Adds helper text with suggested dimensions and aspect ratios to the image meta box. The helper text should not appear in the featured image meta box for posts or pages.