### PR TITLE
SLO-137 & 136: "Preview Changes" button page displays more items on the page than expected & archived post state display

### DIFF
--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -546,7 +546,7 @@ class CPT {
     }
 
     // Add archived status and label to states array.
-    $states['archived'] = 'Archived';
+    $states['archived'] = __( 'Archived', 'gpalab-slo' );
 
     return $states;
   }

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -525,4 +525,29 @@ class CPT {
     }
     echo ' }); </script>';
   }
+
+  /**
+   * Add the 'Archived' post status to display post states.
+   *
+   * @param array $states Post display states.
+   * @return array        Post display states.
+   *
+   * @since 0.0.1
+   */
+  public function add_archived_to_display_post_states( $states ) {
+    global $post;
+
+    $post_type   = $post->post_type;
+    $post_status = $post->post_status;
+
+    // Return default states.
+    if ( 'gpalab-social-link' !== $post_type || 'archived' !== $post_status ) {
+      return $states;
+    }
+
+    // Add archived status and label to states array.
+    $states['archived'] = 'Archived';
+
+    return $states;
+  }
 }

--- a/includes/class-slo.php
+++ b/includes/class-slo.php
@@ -152,6 +152,7 @@ class SLO {
     $this->loader->add_filter( 'post_updated_messages', $plugin_cpt, 'social_link_updated_messages', 10, 1 );
     $this->loader->add_action( 'admin_bar_menu', $plugin_cpt, 'remove_view_from_admin_bar', 999 );
     $this->loader->add_action( 'post_submitbox_misc_actions', $plugin_cpt, 'add_archived_to_status_dropdown' );
+    $this->loader->add_filter( 'display_post_states', $plugin_cpt, 'add_archived_to_display_post_states', 10, 1 );
 
     // Hooks to manage the All Links page.
     $this->loader->add_action( 'manage_gpalab-social-link_posts_custom_column', $plugin_cpt_list, 'populate_custom_columns', 10, 2 );

--- a/public/class-frontend.php
+++ b/public/class-frontend.php
@@ -66,7 +66,8 @@ class Frontend {
     }
 
     $paged   = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
-    $mission = get_post_meta( get_the_ID(), '_gpalab_slo_mission_select', true );
+    $field   = $is_slo_preview ? 'gpalab_slo_mission' : '_gpalab_slo_mission_select';
+    $mission = get_post_meta( get_the_ID(), $field, true );
     // phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
     // phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
     $args = array(


### PR DESCRIPTION
### SLO-136
Displays `–Archived` next to social link items that have the `archived` status. This should only apply to social links and not regular pages and posts.

### SLO-137
Uses `gpalab_slo_mission` for the `get_post_meta` field argument when previewing. Previously, `_gpalab_slo_mission_select` was used for previews, which resulted in an empty mission meta value in the localization.