### PR TITLE
SLO-135: Fix Add Mission button shift

### DIFF
--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -73,6 +73,7 @@ class Settings {
       <button class="page-title-action" id="slo-add-mission" type="button">
         <?php esc_html_e( 'Add a Mission', 'gpalab-slo' ); ?>
       </button>
+      <hr class="wp-header-end">
       <?php
       settings_errors();
 


### PR DESCRIPTION
Adds an `hr` element below the Settings page title so that the **Settings saved** growl notification renders in the correct spot on the page.