### PR TITLE
SL-147: Apply UI copy changes

### DIFF
--- a/admin/class-cpt-list.php
+++ b/admin/class-cpt-list.php
@@ -172,7 +172,9 @@ class CPT_List {
    */
   public function add_custom_bulk_actions( $bulk_actions ) {
     if ( 'archived' !== get_query_var( 'post_status' ) && 'trash' !== get_query_var( 'post_status' ) ) {
+      unset( $bulk_actions['trash'] );
       $bulk_actions['archive'] = __( 'Archive', 'gpalab-slo' );
+      $bulk_actions['trash']   = __( 'Move to Trash', 'gpalab-slo' );
     }
 
     return $bulk_actions;

--- a/admin/class-cpt-list.php
+++ b/admin/class-cpt-list.php
@@ -172,7 +172,7 @@ class CPT_List {
    */
   public function add_custom_bulk_actions( $bulk_actions ) {
     if ( 'archived' !== get_query_var( 'post_status' ) && 'trash' !== get_query_var( 'post_status' ) ) {
-      $bulk_actions['archive'] = __( 'Archive Links', 'gpalab-slo' );
+      $bulk_actions['archive'] = __( 'Archive', 'gpalab-slo' );
     }
 
     return $bulk_actions;

--- a/admin/class-cpt-list.php
+++ b/admin/class-cpt-list.php
@@ -27,10 +27,11 @@ class CPT_List {
    */
   public function add_custom_columns( $defaults ) {
     $columns = array(
-      'cb'                 => $defaults['cb'],
-      'title'              => $defaults['title'],
-      'gpalab_slo_mission' => __( 'Mission', 'gpalab-slo' ),
-      'date'               => $defaults['date'],
+      'cb'                    => $defaults['cb'],
+      'title'                 => $defaults['title'],
+      'gpalab_slo_mission'    => __( 'Mission', 'gpalab-slo' ),
+      'gpalab_slo_grid_image' => __( 'Grid Image', 'gpalab-slo' ),
+      'date'                  => $defaults['date'],
     );
 
     return $columns;
@@ -72,6 +73,11 @@ class CPT_List {
       $human_friendly = is_numeric( $settings_key ) ? $slo_settings[ $settings_key ]['title'] : '';
 
       echo esc_html( $human_friendly );
+    }
+
+    // Populate the Grid Image column.
+    if ( 'gpalab_slo_grid_image' === $column_name ) {
+      echo get_the_post_thumbnail( $post_id, array( 75 ) );
     }
   }
 

--- a/admin/class-cpt-list.php
+++ b/admin/class-cpt-list.php
@@ -172,7 +172,9 @@ class CPT_List {
    */
   public function add_custom_bulk_actions( $bulk_actions ) {
     if ( 'archived' !== get_query_var( 'post_status' ) && 'trash' !== get_query_var( 'post_status' ) ) {
-      unset( $bulk_actions['trash'] );
+      if ( isset( $bulk_actions['trash'] ) ) {
+        unset( $bulk_actions['trash'] );
+      }
       $bulk_actions['archive'] = __( 'Archive', 'gpalab-slo' );
       $bulk_actions['trash']   = __( 'Move to Trash', 'gpalab-slo' );
     }

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -470,6 +470,23 @@ class CPT {
   }
 
   /**
+   * Filters the default untrashed message.
+   *
+   * @param array $messages Array of messages.
+   * @param array $counts   Array of item counts for each message.
+   *
+   * @since 0.0.1
+   */
+  public function social_link_untrashed_message( $messages, $counts ) {
+    $messages['gpalab-social-link'] = array(
+      /* translators: %s: count of untrashed social links */
+      'untrashed' => _n( '%s social link restored from the Trash. Go to Edit Social Link to republish.', '%s social link restored from the Trash. Go to Edit Social Link to republish.', $counts['untrashed'] ),
+    );
+
+    return $messages;
+  }
+
+  /**
    * Remove the View link from the admin bar for social links.
    *
    * @param object $wp_admin_bar  List of nodes to appear in the admin bar.

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -454,16 +454,16 @@ class CPT {
 
     $msg['gpalab-social-link'] = array(
       0  => '', // Unused. Messages start at index 1.
-      1  => __( 'Social link updated.', 'gpalab-slo' ),
+      1  => __( 'Social Link updated.', 'gpalab-slo' ),
       2  => __( 'Custom field updated.', 'gpalab-slo' ),
       3  => __( 'Custom field deleted.', 'gpalab-slo' ),
-      4  => __( 'Social link updated.', 'gpalab-slo' ),
+      4  => __( 'Social Link updated.', 'gpalab-slo' ),
       5  => $is_revision,
-      6  => __( 'Social link published.', 'gpalab-slo' ),
-      7  => __( 'Social link saved.', 'gpalab-slo' ),
-      8  => __( 'Social link submitted.', 'gpalab-slo' ),
+      6  => __( 'Social Link published.', 'gpalab-slo' ),
+      7  => __( 'Social Link saved.', 'gpalab-slo' ),
+      8  => __( 'Social Link submitted.', 'gpalab-slo' ),
       9  => sprintf( $scheduled, '<strong>' . $scheduled_date . '</strong>' ),
-      10 => __( 'Social link draft updated.', 'gpalab-slo' ),
+      10 => __( 'Social Link saved as draft.', 'gpalab-slo' ),
     );
 
     return $msg;

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -129,18 +129,18 @@ class CPT {
    */
   public function gpalab_slo_custom_meta() {
     add_meta_box(
-      'gpalab_slo_mission',
-      __( 'Select Mission (required)', 'gpalab-slo' ),
-      array( $this, 'add_mission_select' ),
+      'gpalab_slo_link',
+      __( 'Add a Link to This Social Post (required)', 'gpalab-slo' ),
+      array( $this, 'add_link_input' ),
       'gpalab-social-link',
       'normal',
       'high'
     );
 
     add_meta_box(
-      'gpalab_slo_link',
-      __( 'Add a Link to This Social Post (required)', 'gpalab-slo' ),
-      array( $this, 'add_link_input' ),
+      'gpalab_slo_mission',
+      __( 'Select Mission (required)', 'gpalab-slo' ),
+      array( $this, 'add_mission_select' ),
       'gpalab-social-link',
       'normal',
       'default'

--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -66,7 +66,7 @@ class CPT {
       'attributes'            => __( 'Item Attributes', 'gpalab-slo' ),
       'parent_item_colon'     => __( 'Parent Item:', 'gpalab-slo' ),
       'all_items'             => __( 'All Links', 'gpalab-slo' ),
-      'add_new_item'          => __( 'Add New Link', 'gpalab-slo' ),
+      'add_new_item'          => __( 'Add New Social Link', 'gpalab-slo' ),
       'add_new'               => __( 'Add New Link', 'gpalab-slo' ),
       'new_item'              => __( 'New Item', 'gpalab-slo' ),
       'edit_item'             => __( 'Edit Social Link', 'gpalab-slo' ),

--- a/admin/class-dashboard.php
+++ b/admin/class-dashboard.php
@@ -44,7 +44,7 @@ class Dashboard {
 
     wp_add_dashboard_widget(
       'gpalab-slo-dashboard-widget',
-      __( 'Social Link Optimizer', 'gpalab-slo' ),
+      __( 'Social Links', 'gpalab-slo' ),
       function () {
         return $this->widget_callback();
       },
@@ -63,7 +63,7 @@ class Dashboard {
     $selected = get_user_meta( get_current_user_id(), 'gpalab_slo_preferred_mission', true );
 
     // Translated text strings used in the dashboard widget.
-    $listing   = __( 'Go to the social links listing page.', 'gpalab-slo' );
+    $listing   = __( 'Go to my Social Links page', 'gpalab-slo' );
     $preferred = __( 'You can use the below dropdown to identify your preferred mission', 'gpalab-slo' );
 
     // Build and escape the settings page URL.
@@ -89,7 +89,7 @@ class Dashboard {
       </div>
       <?php
         submit_button(
-          __( 'Set Your Mission', 'gpalab-slo' ),
+          __( 'Set Default View', 'gpalab-slo' ),
           'primary',
           'submit',
           true,

--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -661,11 +661,12 @@ class Settings {
    * @since 0.0.1
    */
   private function render_danger_section( $id, $post_id ) {
-    $title       = __( 'Danger Zone', 'gpalab-slo' );
-    $warning     = __( 'Warning, altering the below settings can have destructive results. Proceed with caution.', 'gpalab-slo' );
-    $perma_label = __( 'Change permalink:', 'gpalab-slo' );
-    $perma_btn   = __( 'Update Permalink', 'gpalab-slo' );
-    $remove_btn  = __( 'Remove This Mission', 'gpalab-slo' );
+    $title               = __( 'Danger Zone', 'gpalab-slo' );
+    $warning             = __( 'Warning, altering the below settings can have destructive results. Proceed with caution.', 'gpalab-slo' );
+    $perma_label         = __( 'Change permalink:', 'gpalab-slo' );
+    $perma_btn           = __( 'Update Permalink', 'gpalab-slo' );
+    $removal_explanation = __( 'Delete this Social Link page (cannot be restored):', 'gpalab-slo' );
+    $remove_btn          = __( 'Remove This Mission', 'gpalab-slo' );
 
     ?>
     <hr class="gpalab-slo-hr">
@@ -691,6 +692,7 @@ class Settings {
         </button>
       </div>
     </label>
+    <p class="slo-remove-mission-explanation"><?php echo esc_html( $removal_explanation ); ?></p>
     <!-- Button to remove the current section from the settings array. -->
     <button
       class="button button-link-delete slo-remove-mission"

--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -490,20 +490,15 @@ class Settings {
 
       // Render out link to the mission's SLO page.
       if ( isset( $missions[ $index ]['page'] ) ) {
-        $post_id = esc_html( $missions[ $index ]['page'] );
-        $link    = get_permalink( $post_id );
-
-        $link_text = __( 'Social link optimizer page created at', 'gpalab-slo' );
-        $details   = __( 'You can configure the page using the fields below. Use the "Change permalink" field below to change the page URL.', 'gpalab-slo' );
-
+        $post_id   = esc_html( $missions[ $index ]['page'] );
+        $link      = get_permalink( $post_id );
+        $link_text = __( 'Social Link page URL', 'gpalab-slo' );
         ?>
         <p class="gpalab-slo-tabpanel-text">
           <?php echo esc_html( $link_text ); ?>:
             <a href="<?php echo esc_url( $link, array( 'http', 'https' ) ); ?>">
               <?php echo esc_url( $link, array( 'http', 'https' ) ); ?>
             </a>.
-          </br>
-          <?php echo esc_html( $details ); ?>
         </p>
         <?php
       }

--- a/admin/css/gpalab-slo-admin.css
+++ b/admin/css/gpalab-slo-admin.css
@@ -104,6 +104,10 @@
   margin: 1rem 0 1.5rem;
 }
 
+.slo-remove-mission-explanation {
+  margin: 1.5rem 1rem 0;
+}
+
 button.gpalab-slo-avatar-remove.button-secondary,
 input.gpalab-slo-avatar-media-manager.button-secondary {
   margin-left: 1.5rem;

--- a/includes/class-slo.php
+++ b/includes/class-slo.php
@@ -150,6 +150,7 @@ class SLO {
     $this->loader->add_filter( 'preview_post_link', $plugin_cpt, 'hijack_slo_preview' );
     $this->loader->add_action( 'admin_head', $plugin_cpt, 'hide_unused_elements' );
     $this->loader->add_filter( 'post_updated_messages', $plugin_cpt, 'social_link_updated_messages', 10, 1 );
+    $this->loader->add_filter( 'bulk_post_updated_messages', $plugin_cpt, 'social_link_untrashed_message', 10, 2 );
     $this->loader->add_action( 'admin_bar_menu', $plugin_cpt, 'remove_view_from_admin_bar', 999 );
     $this->loader->add_action( 'post_submitbox_misc_actions', $plugin_cpt, 'add_archived_to_status_dropdown' );
     $this->loader->add_filter( 'display_post_states', $plugin_cpt, 'add_archived_to_display_post_states', 10, 1 );

--- a/public/css/gpalab-slo-front.css
+++ b/public/css/gpalab-slo-front.css
@@ -213,6 +213,10 @@ a:active {
   font-weight: 600;
 }
 
+.gpalab-slo-page-title > .preview-badge {
+  text-transform: uppercase;
+}
+
 @media (min-width: 540px) {
   .gpalab-slo-page-title {
     padding-left: 0;

--- a/templates/preview-gpalab-social-link.php
+++ b/templates/preview-gpalab-social-link.php
@@ -51,7 +51,7 @@ require 'template-parts/header-slo.php';
         // Render the preview page title.
         $page_title = isset( $selected_mission ) ? $page_settings['title'] : __( 'All Missions', 'gpalab-slo' );
 
-        $preview_title = '<h1 class="gpalab-slo-page-title">' . $page_title . ' - Preview</h1>';
+        $preview_title = '<h1 class="gpalab-slo-page-title"><span class="preview-badge">Preview</span> – ' . $page_title . '</h1>';
 
         echo wp_kses( $preview_title, 'post' );
 


### PR DESCRIPTION
This PR applies most of the changes from the Confluence document (https://design.atlassian.net/wiki/spaces/LAB20/pages/756088836/User+Feedback+and+UI+Copy+Updates?focusedCommentId=815955975):

* Updates the dashboard widget link and button text. However, we still haven't completely settled on the changes, based on the comment thread in the document. So, we may need to revisit this when we come to a final decision.
* Updates the text at the top of each mission tab on the settings page.
* Adds a message above the remove mission button that the mission can't be restored if removed.
* Filters the restored from trash message with additional instructions on how to republish the item.
* Reverses the position of the social link and select a mission meta boxes so that social links appears first.
* Changes the text in the bulk actions dropdown to "Archive" from "Archive Links".
* Changes the page heading above the title field on the add new link page to "Add New Social Link" to match the edit link page.
* Changes the confirmation alert message for saved drafts to "Social Link saved as draft". I did not make the other two proposed changes for archived and pending review since the available messages seem to be order specific and are limited to ten. Perhaps there's a way to do it that I'm overlooking.
* Re-orders the bulk action dropdown options so that "Archive" appears second. I didn't come across a WordPress way to do this, so I `unset` the trashed option and reassigned it after assigning the archive option.
* Adjusts the preview badge styling so that the "Preview" text comes before the mission title and is all caps. In the last user test I was in, the user didn't notice the preview text at the end, and this should make it easier for users to see.
* Adds a small thumbnail to the social links dashboard list.

This PR does not include a couple items from the document:

* The proposed button text change to "Save as Archive". As I mentioned in my comment for this item, I figured out how to do this with JavaScript, but clicking the "Save as Archive" button results in the button text reverting to "Save Draft" momentarily while the saving process is happening. This could be confusing to users, so I didn't include the JavaScript I wrote. Plus, there could be a better, more WordPress way, to handle this that I've not yet come across.
* The proposed remove mission confirmation dialog. I'm not sure it's needed since we have the Danger Zone warning and the new warning message above the remove mission button, but I also see how it could prevent inadvertent deletions if a users didn't read the two prior warnings. If we decide that this is needed, I think it should be a separate ticket since it's more than a quick copy adjustment.