### PR TITLE
Add a link to mission page in the select a mission metabox

### DIFF
--- a/admin/class-cpt.php
+++ b/admin/class-cpt.php
@@ -213,6 +213,29 @@ class CPT {
     $missions = get_option( 'gpalab-slo-settings' );
 
     $this->populate_mission_select( $selected, $missions, 'gpalab_slo_mission' );
+
+    if (! empty( $selected ) ) {
+      $missions = get_option( 'gpalab-slo-settings' );
+
+      // Search for selected mission among the mission sessions and return it's data.
+      $settings_key  = array_search( $selected, array_column( $missions, 'id' ), true );
+      $settings = is_numeric( $settings_key ) ? $missions[ $settings_key ] : array();
+
+      /* translators: %s: the tile of the selected mission */
+      $text  = __( 'Go to the %s page', 'gpalab-slo' );
+      $link  = get_permalink($settings['page']);
+      $title = $settings['title'];
+
+      ?>
+        <br>
+        <div style="align-items:center;display:flex;margin-top:1rem;">
+          <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="img" viewBox="0 0 512 512" height="15px" width="15px"><path fill="currentColor" d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"/></svg>
+          <?php printf( '<a href=' . esc_attr( $link ) . ' target="_blank" style="margin-left:0.5rem">' . esc_html( $text ) . '</a>', esc_html( $title ) ); ?>
+        </div>
+      <?php
+      
+      
+    }
   }
 
   /**


### PR DESCRIPTION
- Only shows link when a mission is selected (i.e. saved to the links metadata)
- Per designer's request, the link opens in a new tab and is prefixed with an open in new tab icon
- Styles are inlined to avoid loading an additional CSS file onto the CPT edit screen